### PR TITLE
calendars/workshops: Increase the end time of recurring events

### DIFF
--- a/calendars/workshops.yaml
+++ b/calendars/workshops.yaml
@@ -31,7 +31,7 @@ events:
       interval: {days: 1}
       until: 2022-03-24 8:50:00
   - <<: *cr-march-2022
-    begin: 2022-03-29 08:50:00
+    begin: 2022-03-29 12:30:00
     repeat:
       interval: {days: 1}
-      until: 2022-03-31 8:50:00
+      until: 2022-03-31 09:00:00


### PR DESCRIPTION
- Apple Calendar seemed to exclude the last day if the "repeat until"
  was exactly the start time of the last day.
- Add two different options: time + 10 minutes and event stop time.
  Let's see if either of these work.
- Review: automerge
