### PR TITLE
Diana hackathons 2022

### DIFF
--- a/calendars/team.yaml
+++ b/calendars/team.yaml
@@ -23,12 +23,3 @@ events:
       until: 2022-12-31
 
 
-  - summary: CodeRefinery Kick-off 2022
-    location: Aalto University, Finland
-    #timezone: Europe/Helsinki
-    begin: 2022-05-19 11:00:00 +03:00
-    end: 2022-05-20 14:00:00 +03:00
-    description: |
-      Details: https://hackmd.io/@coderefinery/kickoff2022
-
-      In-person, we will try to make online participation, too.

--- a/calendars/team.yaml
+++ b/calendars/team.yaml
@@ -22,4 +22,22 @@ events:
       interval: {weeks: 1}
       until: 2022-12-31
 
+  # Online Hackathon about Improving Workshop Registration May 2022
+  - summary: Improving Workshop Registration Online Hackathon
+    location: https://uit.zoom.us/j/62141400945
+    begin: 2022-05-03 13:15:00
+    end: 2022-05-03 16:00:00
+    description: |
+      Details: https://hackmd.io/@coderefinery/hackathon-workshop-registration
 
+      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.
+
+  # Online Hackathon about Measuring the Impact of CodeRefinery Workshops May 2022
+  - summary: Measuring Impact of CodeRefinery Workshops Online Hackathon
+    location: https://uit.zoom.us/j/62141400945
+    begin: 2022-05-18 09:00:00
+    end: 2022-05-18 12:00:00
+    description: |
+      Details: https://hackmd.io/@coderefinery/hackathon-measure-impact
+
+      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.

--- a/calendars/workshops.yaml
+++ b/calendars/workshops.yaml
@@ -35,25 +35,3 @@ events:
     repeat:
       interval: {days: 1}
       until: 2022-03-31 09:00:00
-
-  # Online Hackathon about Improving Workshop Registration May 2022
-  - summary: Improving Workshop Registration Online Hackathon
-    location: https://uit.zoom.us/j/62141400945
-    begin: 2022-05-03 13:15:00
-    end: 2022-05-03 16:00:00
-    description: |
-      Details: https://hackmd.io/@coderefinery/hackathon-workshop-registration 
-
-      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.
-
-  # Online Hackathon about Measuring the Impact of CodeRefinery Workshops May 2022
-  - summary: Measuring Impact of CodeRefinery Workshops Online Hackathon
-    location: https://uit.zoom.us/j/62141400945
-    begin: 2022-05-18 09:00:00
-    end: 2022-05-18 12:00:00
-    description: |
-      Details: https://hackmd.io/@coderefinery/hackathon-measure-impact
-
-      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.
-
-

--- a/calendars/workshops.yaml
+++ b/calendars/workshops.yaml
@@ -35,3 +35,25 @@ events:
     repeat:
       interval: {days: 1}
       until: 2022-03-31 09:00:00
+
+  # Online Hackathon about Improving Workshop Registration May 2022
+  - summary: Improving Workshop Registration Online Hackathon
+    location: https://uit.zoom.us/j/62141400945
+    begin: 2022-05-03 13:15:00
+    end: 2022-05-03 16:00:00
+    description: |
+      Details: https://hackmd.io/@coderefinery/hackathon-workshop-registration 
+
+      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.
+
+  # Online Hackathon about Measuring the Impact of CodeRefinery Workshops May 2022
+  - summary: Measuring Impact of CodeRefinery Workshops Online Hackathon
+    location: https://uit.zoom.us/j/62141400945
+    begin: 2022-05-18 09:00:00
+    end: 2022-05-18 12:00:00
+    description: |
+      Details: https://hackmd.io/@coderefinery/hackathon-measure-impact
+
+      If you can only participate some of the time, the first hour is perhaps the most important so that we get a broad input.
+
+


### PR DESCRIPTION
- removed the kick-off event initially planned for May 2022
- added the two online hackathons on workshop registration and measures of impact, to be had May 3 and 18, respectively