### PR TITLE
calendars/workshop-2022-09-20: Add calendar of workshop

### DIFF
--- a/calendars/workshop-2022-09-20.yaml
+++ b/calendars/workshop-2022-09-20.yaml
@@ -1,0 +1,177 @@
+name: CodeRefinery Workshop, 20-22 and 27-29 September 2022
+description: |
+  Workshop schedule for Autumn 2022 - each session separately.
+timezone: Europe/Stockholm
+
+events:
+  - &base
+    location: https://twitch.tv/coderefinery
+
+  - &connecting
+    summary: Connecting time
+    location: https://twitch.tv/coderefinery
+    begin: 2022-09-20 08:50:00
+    duration: { minutes: 10 }
+    description: |
+      Connect now and hear about us and the course
+  - {<<: *connecting,  begin: 2022-09-21 08:50:00}
+  - {<<: *connecting,  begin: 2022-09-22 08:50:00}
+  - {<<: *connecting,  begin: 2022-09-27 08:50:00}
+  - {<<: *connecting,  begin: 2022-09-28 08:50:00}
+  - {<<: *connecting,  begin: 2022-09-29 08:50:00}
+
+  - <<: *base
+    summary: Introduction
+    begin: 2022-09-20 09:00:00
+    end: 2022-09-20 09:20:00
+    description: |
+      Workshop introduction: https://github.com/coderefinery/workshop-intro/blob/master/README.md
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Introduction to version control part 1/2
+    begin: 2022-09-20 09:20:00
+    end: 2022-09-20 12:30:00
+    description: |
+      https://coderefinery.github.io/git-intro/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Introduction to version control part 2/2
+    begin: 2022-09-21 09:00:00
+    end: 2022-09-21 12:30:00
+    description: |
+      https://coderefinery.github.io/git-intro/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Collaborative distributed version control
+    begin: 2022-09-22 09:00:00
+    end: 2022-09-22 12:30:00
+    description: |
+      https://coderefinery.github.io/git-collaborative/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Introduction to week 2
+    begin: 2022-09-27 09:00:00
+    duration: { minutes: 15 }
+    description: |
+      https://github.com/coderefinery/workshop-intro/blob/master/README.md
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Reproducible research and FAIR data
+    begin: 2022-09-27 09:00:00
+    end: 2022-09-27 11:15:00
+    description: |
+      https://coderefinery.github.io/reproducible-research/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Social coding and open software
+    begin: 2022-09-27 11:15:00
+    end: 2022-09-27 12:30:00
+    description: |
+      https://coderefinery.github.io/social-coding/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Jupyter
+    begin: 2022-09-28 09:00:00
+    end: 2022-09-28 10:45:00
+    description: |
+      https://coderefinery.github.io/jupyter/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Documentation
+    begin: 2022-09-28 10:45:00
+    end: 2022-09-28 12:30:00
+    description: |
+      https://coderefinery.github.io/documentation/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Software testing
+    begin: 2022-09-29 09:00:00
+    end: 2022-09-29 10:45:00
+    description: |
+      https://coderefinery.github.io/testing/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Modular code development
+    begin: 2022-09-29 11:00:00
+    end: 2022-09-29 12:15:00
+    description: |
+      https://coderefinery.github.io/modular-type-along/
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.
+
+  - <<: *base
+    summary: Concluding remarks and where to go from here
+    begin: 2022-09-29 12:15:00
+    end: 2022-09-29 12:30:00
+    description: |
+      https://github.com/coderefinery/workshop-outro/blob/master/README.md
+
+      CodeRefinery workshop 2022 September: https://coderefinery.github.io/2022-09-20-workshop/
+
+      Note: All times are approximate and will be adjusted based on
+      the schedule.  Join at least 10 minutes early just in case.  At
+      least 10 minute break every hour, sometime between xx:50--xx:10.


### PR DESCRIPTION
- This contains the public events of the September 2022 workshop, but
  not (yet) things like the installation times.  The descriptions
  could be improved in the future.
- Review: I have checked, but it's worth someone verifying all of the
  times are correct (either before merging, or by viewing it after
  merging).
