### PR TITLE
calendars/team: Update for 2023

### DIFF
--- a/calendars/community.yaml
+++ b/calendars/community.yaml
@@ -10,31 +10,36 @@ events:
   - &ccall
     summary: CodeRefinery Community call
     location: https://hackmd.io/@coderefinery/community-call
-    begin: 2022-01-31 14:00:00
+    begin: 2022-01-09 14:00:00
     duration: { hours: 1 }
     description: |
       CodeRefinery community meeting, everyone is most welcome!
 
       Agenda/connection details: https://hackmd.io/@coderefinery/community-call
-
   - <<: *ccall
-    begin: 2022-02-28 14:00:00
+    begin: 2023-01-09 14:00:00 # Second week of the year
   - <<: *ccall
-    begin: 2022-04-04 14:00:00
+    begin: 2023-02-06 14:00:00
   - <<: *ccall
-    begin: 2022-05-02 14:00:00
+    begin: 2023-03-06 14:00:00
   - <<: *ccall
-    begin: 2022-07-04 14:00:00  # after midsummer, vacation for many in the Nordics
+    begin: 2023-04-03 14:00:00
   - <<: *ccall
-    begin: 2022-08-01 14:00:00
+    begin: 2023-05-08 14:00:00  # first week is 1-may holiday
   - <<: *ccall
-    begin: 2022-09-05 14:00:00
+    begin: 2023-06-05 14:00:00
   - <<: *ccall
-    begin: 2022-10-03 14:00:00
+    begin: 2023-07-03 14:00:00  # Summer holiday
   - <<: *ccall
-    begin: 2022-11-07 14:00:00
+    begin: 2023-08-07 14:00:00
   - <<: *ccall
-    begin: 2022-12-05 14:00:00
+    begin: 2023-09-04 14:00:00
+  - <<: *ccall
+    begin: 2023-10-02 14:00:00
+  - <<: *ccall
+    begin: 2023-11-06 14:00:00
+  - <<: *ccall
+    begin: 2023-12-04 14:00:00
 
 
   - summary: Community teaching workshop

--- a/calendars/community.yaml
+++ b/calendars/community.yaml
@@ -10,7 +10,7 @@ events:
   - &ccall
     summary: CodeRefinery Community call
     location: https://hackmd.io/@coderefinery/community-call
-    begin: 2022-01-09 14:00:00
+    begin: 2023-01-09 14:00:00
     duration: { hours: 1 }
     description: |
       CodeRefinery community meeting, everyone is most welcome!

--- a/calendars/team.yaml
+++ b/calendars/team.yaml
@@ -19,7 +19,10 @@ events:
       Agenda and connection details: https://hackmd.io/@coderefinery/team-meeting
     repeat:
       interval: {weeks: 1}
-      until: 2022-12-31
+      until: 2023-12-31
+      except_on:
+        - 2022-12-26 14:00:00
+
 
   # Online Hackathon about Improving Workshop Registration May 2022
   - summary: Improving Workshop Registration Online Hackathon


### PR DESCRIPTION
- Extend team meeting until 2023
- Change community call dates to 2023 (removing the 2022 ones, which
  will make the file longer unnecessarily)
  - Review: should the old dates actually be left in there?
- Remove 23.dec for a team meeting
- Review: check the new content
