### PR TITLE
moving end date of writing retreat

### DIFF
--- a/calendars/team.yaml
+++ b/calendars/team.yaml
@@ -71,6 +71,6 @@ events:
     end: 2023-08-23 15:00:00
     repeat:
       interval: { days: 1 }
-      until: 2023-08-25
+      until: 2023-08-26
     description: |
       Details: Lesson development and any other collaborative writing we want to do or discuss.


### PR DESCRIPTION
- what I wanted was Aug 23-25
- but now the event shows up in my cal for Aug 23-24
- is the "until" until 1 past the end?