### PR TITLE
Adding partner calendars, requires updated git-calendar

### DIFF
--- a/calendars/all.yaml
+++ b/calendars/all.yaml
@@ -7,5 +7,6 @@ include:
   - community.yaml
   - workshop-2023-09-19.yaml
   - workshop-2024-03-12.yaml
+  - partners.yaml
 
 events: [ ]

--- a/calendars/partners.yaml
+++ b/calendars/partners.yaml
@@ -1,0 +1,11 @@
+name: All Workshop/Training events by partners
+description: |
+  All workshop and training events by partners of CodeRefinery.
+include:
+    # Aalto SciComp
+  - https://aaltoscicomp.github.io/public-calendar/training.ics  
+    # ENCCS
+  - https://enccs.se/events-at-enccs/list/?shortcode=5210815c&ical=1
+   # PDC
+  - https://www.pdc.kth.se/api/icalendar/export/2.78462?l=en_GB&c=all
+events: [ ]

--- a/calendars/training.yaml
+++ b/calendars/training.yaml
@@ -1,0 +1,10 @@
+name: All Training events, both paid and open
+description: |
+  Training events offered by Coderefinery or its partners. This includes both free and paid events.
+include:
+  - workshops.yaml
+  - workshop-2023-09-19.yaml
+  - workshop-2024-03-12.yaml
+  - partners.yaml  
+
+events: [ ]


### PR DESCRIPTION
Only merge this, once the latest git-calendar is merged. 
This requires proper support for additional included calendars.