### PR TITLE
do not include community cal into team cal

### DIFF
--- a/calendars/team.yaml
+++ b/calendars/team.yaml
@@ -3,8 +3,6 @@ description: |
   People who actively contribute.  About one meeting per
   week (this calendar includes the community calls)
 timezone: Europe/Stockholm
-include:
-  - community.yaml
 
 events:
   - summary: "CodeRefinery team meeting"


### PR DESCRIPTION
otherwise somebody subscribed to "all", gets
all community events twice